### PR TITLE
Fix/incomplete model cache validation

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6578c060b5804d2e2094b6501ac714958ff4047f175532371e9d112910ad9e92",
+  "originHash" : "4c93aa61c07be58aea5829de6d3f80342b6aa166f5e1032c0bac7c2deeb27479",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -89,6 +89,15 @@
       "state" : {
         "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
         "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "1bb939fe7bbb00b8f8bab664cc90020c035c08d9",
+        "version" : "1.1.0"
       }
     },
     {

--- a/Sources/VoxtralRuntime/ModelUtils.swift
+++ b/Sources/VoxtralRuntime/ModelUtils.swift
@@ -37,11 +37,12 @@ public enum ModelUtils {
 
         if FileManager.default.fileExists(atPath: modelDir.path) {
             let files = try? FileManager.default.contentsOfDirectory(at: modelDir, includingPropertiesForKeys: nil)
-            let hasRequiredFiles = files?.contains { $0.pathExtension == requiredExtension } ?? false
-            if hasRequiredFiles {
+            let hasWeights = files?.contains { $0.pathExtension == requiredExtension } ?? false
+            let hasConfig = FileManager.default.fileExists(atPath: modelDir.appendingPathComponent("config.json").path)
+            let hasTokenizer = FileManager.default.fileExists(atPath: modelDir.appendingPathComponent("tekken.json").path)
+            if hasWeights && hasConfig && hasTokenizer {
                 let configPath = modelDir.appendingPathComponent("config.json")
-                if FileManager.default.fileExists(atPath: configPath.path),
-                   let configData = try? Data(contentsOf: configPath),
+                if let configData = try? Data(contentsOf: configPath),
                    (try? JSONSerialization.jsonObject(with: configData)) != nil {
                     progressHandler?("Using cached model files")
                     return modelDir

--- a/Sources/VoxtralRuntime/ModelUtils.swift
+++ b/Sources/VoxtralRuntime/ModelUtils.swift
@@ -53,21 +53,40 @@ public enum ModelUtils {
         try FileManager.default.createDirectory(at: modelDir, withIntermediateDirectories: true)
 
         let allowedExtensions: Set<String> = ["*.\(requiredExtension)", "*.safetensors", "*.json", "*.txt", "*.wav"]
-        progressHandler?("Downloading model files")
+        progressHandler?("Fetching file list")
 
-        _ = try await client.downloadSnapshot(
-            of: repoID,
-            kind: .model,
-            to: modelDir,
-            revision: "main",
-            matching: Array(allowedExtensions),
-            progressHandler: { progress in
-                let total = max(progress.totalUnitCount, 1)
-                let completed = min(progress.completedUnitCount, total)
-                let percent = Int((Double(completed) / Double(total)) * 100.0)
-                progressHandler?("Downloading model files \(completed)/\(total) (\(percent)%)")
+        let entries = try await client.listFiles(in: repoID, kind: .model, revision: "main", recursive: true)
+            .filter { entry in
+                guard entry.type == .file else { return false }
+                return allowedExtensions.contains { glob in
+                    fnmatch(glob, entry.path, 0) == 0
+                }
             }
-        )
+            .sorted { ($0.size ?? 0) < ($1.size ?? 0) }
+
+        progressHandler?("Downloading model files")
+        var totalBytes: Int64 = 0
+        var completedBytes: Int64 = 0
+        for entry in entries {
+            totalBytes += Int64(entry.size ?? 0)
+        }
+
+        for (index, entry) in entries.enumerated() {
+            let destination = modelDir.appendingPathComponent(entry.path)
+            if FileManager.default.fileExists(atPath: destination.path) {
+                progressHandler?("Cached \(entry.path) (\(index + 1)/\(entries.count))")
+                continue
+            }
+            progressHandler?("Downloading \(entry.path) (\(index)/\(entries.count))")
+            _ = try await client.downloadFile(
+                entry,
+                from: repoID,
+                to: destination,
+                kind: .model,
+                revision: "main"
+            )
+            progressHandler?("Downloaded \(entry.path) (\(index + 1)/\(entries.count))")
+        }
         progressHandler?("Download complete")
 
         return modelDir

--- a/Sources/VoxtralRuntime/ModelUtils.swift
+++ b/Sources/VoxtralRuntime/ModelUtils.swift
@@ -48,6 +48,21 @@ public enum ModelUtils {
                     return modelDir
                 }
             }
+
+            // Cache validation failed — remove required files that are missing or corrupt
+            // so the download loop will re-fetch them instead of skipping existing files.
+            let requiredFiles = ["config.json", "tekken.json"]
+            for name in requiredFiles {
+                let path = modelDir.appendingPathComponent(name)
+                guard FileManager.default.fileExists(atPath: path.path),
+                      let data = try? Data(contentsOf: path),
+                      !data.isEmpty,
+                      (try? JSONSerialization.jsonObject(with: data)) != nil
+                else {
+                    try? FileManager.default.removeItem(at: path)
+                    continue
+                }
+            }
         }
 
         try FileManager.default.createDirectory(at: modelDir, withIntermediateDirectories: true)

--- a/Sources/VoxtralRuntime/VoxtralRealtime.swift
+++ b/Sources/VoxtralRuntime/VoxtralRealtime.swift
@@ -448,11 +448,11 @@ public extension VoxtralRealtimeModel {
         return model
     }
 
-    static func fromPretrained(
+    static func downloadPretrained(
         _ modelPath: String,
         hfToken: String? = nil,
         progressHandler: (@Sendable (String) -> Void)? = nil
-    ) async throws -> VoxtralRealtimeModel {
+    ) async throws -> URL {
         let resolvedToken: String? = hfToken
             ?? ProcessInfo.processInfo.environment["HF_TOKEN"]
             ?? Bundle.main.object(forInfoDictionaryKey: "HF_TOKEN") as? String
@@ -465,13 +465,24 @@ public extension VoxtralRealtimeModel {
             )
         }
 
-        let modelDir = try await ModelUtils.resolveOrDownloadModel(
+        return try await ModelUtils.resolveOrDownloadModel(
             repoID: repoID,
             requiredExtension: "safetensors",
             hfToken: resolvedToken,
             progressHandler: progressHandler
         )
+    }
 
+    static func fromPretrained(
+        _ modelPath: String,
+        hfToken: String? = nil,
+        progressHandler: (@Sendable (String) -> Void)? = nil
+    ) async throws -> VoxtralRealtimeModel {
+        let modelDir = try await downloadPretrained(
+            modelPath,
+            hfToken: hfToken,
+            progressHandler: progressHandler
+        )
         return try fromDirectory(modelDir, progressHandler: progressHandler)
     }
 

--- a/Sources/supervoxtral/AppDelegate.swift
+++ b/Sources/supervoxtral/AppDelegate.swift
@@ -332,6 +332,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func refreshStatusUI() {
+        switch currentState {
+        case .loading:
+            toggleItem?.title = "Start Dictation"
+            toggleItem?.isEnabled = false
+        case .idle, .error:
+            toggleItem?.title = "Start Dictation"
+            toggleItem?.isEnabled = true
+        case .listening:
+            toggleItem?.title = "Stop Dictation"
+            toggleItem?.isEnabled = true
+        }
+
         hotkeyDetailItem?.title = "Hotkey: \(settings?.hotkey ?? "right_cmd")"
         stateDetailItem?.title = "Status: \(statusDetailText)"
 


### PR DESCRIPTION
## Summary 
- Fix incomplete model downloads causing "tekken.json not found" on startup
- Cache validation now checks for all required files (weights, config, tokenizer) before skipping download 
- Download timeout no longer kills file transfers — timeout applies only to model initialization
- Files download smallest-first so metadata files (config.json, tekken.json) are fetched before the 4.7 GB weights
- Progress reporting improved 

 ## Root cause
The 240s model load timeout wrapped both download and initialization. Large model downloads exceeded this, cancelling mid-transfer. On next launch, the partial cache (missing tekken.json) passed validation and the app failed without re-downloading.